### PR TITLE
OpenShift support + default namespace

### DIFF
--- a/kubectl-socks5-proxy
+++ b/kubectl-socks5-proxy
@@ -70,6 +70,10 @@ spec:
     image: ${image}
     ports:
     - containerPort: 1080
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
   nodeSelector:
     "kubernetes.io/os": linux
 EOF

--- a/kubectl-socks5-proxy
+++ b/kubectl-socks5-proxy
@@ -8,7 +8,7 @@
 MAX_POD_CREATION_TIME=10  # unit: second
 DEFAULT_NAME=$(echo ${USER}-proxy|sed -e 's/[^[:alnum:]|-]//g'|tr '[:upper:]' '[:lower:]')
 DEFAULT_PORT=1080
-DEFAULT_PROXY_NAMESPACE=default
+DEFAULT_PROXY_NAMESPACE="$(kubectl config view --minify -o jsonpath='{..namespace}')"
 DEFAULT_PROXY_IMAGE=serjs/go-socks5-proxy
 
 help(){


### PR DESCRIPTION
Make `kubectl socks5-proxy` Just Work™ against a multitenant OpenShift 4.x cluster (no cluster-admin access)

- Deduce the namespace to use from the current Kubeconfig
- Set `resources.requests` (required for the pod to schedule on OpenShift)
