### PR TITLE
fix(namespace): default proxy namespace to default when unset

### DIFF
--- a/kubectl-socks5-proxy
+++ b/kubectl-socks5-proxy
@@ -8,7 +8,8 @@
 MAX_POD_CREATION_TIME=10  # unit: second
 DEFAULT_NAME=$(echo ${USER}-proxy|sed -e 's/[^[:alnum:]|-]//g'|tr '[:upper:]' '[:lower:]')
 DEFAULT_PORT=1080
-DEFAULT_PROXY_NAMESPACE="$(kubectl config view --minify -o jsonpath='{..namespace}')"
+DEFAULT_PROXY_NAMESPACE="$(kubectl config view --minify -o jsonpath='{..namespace}' 2>/dev/null || true)"
+DEFAULT_PROXY_NAMESPACE="${DEFAULT_PROXY_NAMESPACE:-default}"
 DEFAULT_PROXY_IMAGE=serjs/go-socks5-proxy
 
 help(){


### PR DESCRIPTION
This pull request improves the robustness of the `kubectl-socks5-proxy` script by ensuring a default namespace is always set, even if the current Kubernetes context does not specify one. The main change is:

Namespace handling improvements:

* Updated the assignment of `DEFAULT_PROXY_NAMESPACE` to suppress errors when querying the current namespace, and to default to `"default"` if no namespace is set in the current context.